### PR TITLE
adding config object and params for contract

### DIFF
--- a/deployer.js
+++ b/deployer.js
@@ -28,12 +28,16 @@ exports.deploy = function(contractFile, params, config) {
   // Assign defaults if not exist
   config.gasPrice = ('gasPrice' in config) ?  config.gasPrice : '1000000';
   config.port = ('port' in config) ? config.port : 8545;
+  config.startServer = ('startServer' in config) ? config.startServer : true;
 
   if (!fs.existsSync(contractFile)) {
     throw Error("Can not read the contract file.");
   }
 
-  server.listen(config.port);
+  if (config.startServer === true){
+    server.listen(config.port);
+  }
+
   let web3URL = 'http://localhost:' + config.port;
   let web3 = new Web3(new Web3.providers.HttpProvider(web3URL));
   console.log('Ganache runs on : %s', web3URL);

--- a/index.js
+++ b/index.js
@@ -1,12 +1,16 @@
 const deployer = require('./deployer');
 
-exports.deploy = function(contractFile, gasPrice, port = 8545) {
+/**
+ * @param contractFile a solidity contract
+ * @param params an array of parameters to pass to contract
+ * @param config web3 default configuration
+ */
+exports.deploy = function(contractFile, params = [], config = {}) {
   if (!contractFile) {
     throw 'The contract file must be provided';
   }
 
-
-  return deployer.deploy(port, contractFile, gasPrice);
+  return deployer.deploy(contractFile, params, config);
 }
 
 exports.buildABI = function(contractFile) {


### PR DESCRIPTION
Amended to allow parameters to be passed to contracts .
Now passes config object allowing future parameters for web3 to be more easily added.
Also added ability to avoid creating new server.

These are especially useful in cases where we want to deploy more than one contract and when there are dependencies between contracts.